### PR TITLE
Add requirement to sort tokens

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,6 +1,7 @@
 {
   "contributors": [
     "expede",
-    "MichaelMure"
+    "MichaelMure",
+    "alanshaw"
   ]
 }

--- a/Notices.md
+++ b/Notices.md
@@ -30,6 +30,14 @@ Specification version: 0.0.0 or later
 
 ---------------------------------------------------------------------------------
 
+Licensee’s name: Alan Shaw
+
+Authorized individual and system identifier: alanshaw
+
+Specification version: 0.0.0 or later
+
+---------------------------------------------------------------------------------
+
 ## Withdrawals
 
 Name of party withdrawing:

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ The UCAN spec itself is transport agnostic. This specification describes how to 
 
 UCAN tokens, regardless of their kind ([Delegation], [Invocation], [Revocation], [Promise]) MUST be first signed and serialized into DAG-CBOR bytes according to their respective specification. As the token's CID is not part of the serialized container, any CID returned by this operation is to be ignored.
 
-All the tokens' bytes MUST be assembled in a [CBOR] array. The ordering of tokens in the array MUST NOT matter. Tokens in the array SHOULD NOT have duplicate entries and SHOULD be ordered bytewise to ensure a deterministic encoding.
+All the tokens' bytes MUST be assembled in a [CBOR] array. The ordering of tokens in the array MUST NOT matter. This array SHOULD NOT have duplicate entries and SHOULD be ordered bytewise to ensure a deterministic encoding.
 
 That array is then inserted as the value under the `ctn-v1` string key, in a CBOR map. There MUST NOT be other keys.
 

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ The UCAN spec itself is transport agnostic. This specification describes how to 
 
 UCAN tokens, regardless of their kind ([Delegation], [Invocation], [Revocation], [Promise]) MUST be first signed and serialized into DAG-CBOR bytes according to their respective specification. As the token's CID is not part of the serialized container, any CID returned by this operation is to be ignored.
 
-All the tokens' bytes MUST be assembled in a [CBOR] array. The ordering of tokens in the array MUST NOT matter. This array SHOULD NOT have duplicate entries and SHOULD be ordered bytewise to ensure a deterministic encoding.
+All the tokens' bytes MUST be assembled in a [CBOR] array. The ordering of tokens in the array MUST NOT matter. This array SHOULD NOT have duplicate entries and MUST be ordered bytewise to ensure a deterministic encoding.
 
 That array is then inserted as the value under the `ctn-v1` string key, in a CBOR map. There MUST NOT be other keys.
 

--- a/Readme.md
+++ b/Readme.md
@@ -87,7 +87,7 @@ While it is tempting to write a single implementation to read and write a contai
 
 # 5 Acknowledgments
 
-Many thanks to all the [Fission] team and in particular to [Brooklyn Zelenka] for creating and pushing [UCAN] and other critical pieces like [WNFS], and generally being awesome and supportive people.
+Many thanks to all the Fission team and in particular to [Brooklyn Zelenka] for creating and pushing [UCAN] and other critical pieces like [WNFS], and generally being awesome and supportive people.
 
 <!-- External Links -->
 
@@ -96,13 +96,12 @@ Many thanks to all the [Fission] team and in particular to [Brooklyn Zelenka] fo
 [CBOR]: https://www.rfc-editor.org/rfc/rfc8949.html
 [Consensys]: https://consensys.io/
 [Delegation]: https://github.com/ucan-wg/delegation
-[Fission]: https://fission.codes
 [GZIP]: https://datatracker.ietf.org/doc/html/rfc1952
 [Hugo Dias]: https://github.com/hugomrdias
 [Invocation]: https://github.com/ucan-wg/invocation
 [Michael Muré]: https://github.com/MichaelMure/
 [Promise]: https://github.com/ucan-wg/promise/tree/v1-rc1
-[Revocation]: https://github.com/ucan-wg/revocation/tree/first-draft
+[Revocation]: https://github.com/ucan-wg/revocation
 [UCAN]: https://github.com/ucan-wg/spec
 [WNFS]: https://github.com/wnfs-wg
 [cache poisoning]: https://en.wikipedia.org/wiki/Cache_poisoning

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ The UCAN spec itself is transport agnostic. This specification describes how to 
 
 UCAN tokens, regardless of their kind ([Delegation], [Invocation], [Revocation], [Promise]) MUST be first signed and serialized into DAG-CBOR bytes according to their respective specification. As the token's CID is not part of the serialized container, any CID returned by this operation is to be ignored.
 
-All the tokens' bytes MUST be assembled in a [CBOR] array. The ordering of tokens in the array MUST NOT matter. This array SHOULD NOT have duplicate entries.
+All the tokens' bytes MUST be assembled in a [CBOR] array. The ordering of tokens in the array MUST NOT matter. Tokens in the array SHOULD NOT have duplicate entries and SHOULD be ordered bytewise to ensure a deterministic encoding.
 
 That array is then inserted as the value under the `ctn-v1` string key, in a CBOR map. There MUST NOT be other keys.
 

--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ Many thanks to all the [Fission] team and in particular to [Brooklyn Zelenka] fo
 [Brooklyn Zelenka]: https://github.com/expede
 [CBOR]: https://www.rfc-editor.org/rfc/rfc8949.html
 [Consensys]: https://consensys.io/
-[Delegation]: https://github.com/ucan-wg/delegation/tree/v1_ipld
+[Delegation]: https://github.com/ucan-wg/delegation
 [Fission]: https://fission.codes
 [GZIP]: https://datatracker.ietf.org/doc/html/rfc1952
 [Hugo Dias]: https://github.com/hugomrdias


### PR DESCRIPTION
The container is specified to be CBOR encoded, but the tokens within the container are themselves an _array_ of bytes.

It means that you can add the _same_ tokens to the container in a _different_ order and get a _different encoded representation_.

This PR updates the wording to REQUIRE that the tokens are ordered bytewise, which, when followed will ensure that there is only 1 set of bytes that correspond to the container contents. i.e. adding determinism.